### PR TITLE
Added Accessible tag to documentation

### DIFF
--- a/docs/room-creation/getting-started.md
+++ b/docs/room-creation/getting-started.md
@@ -109,6 +109,9 @@ For public rooms we require a minimum of 4 tags. Some ideas for what we expect a
   - Burp Suite, Metasploit, SQLMap etc.
 - Vulnerable Protocols
   - SMB, POP3, etc.
+- Accessible, if applicable
+  - For accessible rooms ([Learn more here](https://www.w3.org/standards/webdesign/accessibility)).
+  - Ex: Internal, Shodan.io, Introductory Networking.
 
 Rooms which do not include tags will not be made public although challenges have some leniency due to spoilers. For example, we are not expecting you list CVE numbers that will spoil the challenge.
 


### PR DESCRIPTION
TryHackMe has a tag, accessible, for rooms that are considered accessible.

We are aiming to include this on more and more rooms.

Room creators should know about it and add it if it applies.

I have linked to the W3 documentation on accessibility, which is as close as to a de-facto standard on A11Y on the internet there is.